### PR TITLE
Feature: snapshot improvements

### DIFF
--- a/api/schemas/decks.py
+++ b/api/schemas/decks.py
@@ -222,6 +222,10 @@ class SnapshotIn(BaseModel):
     is_public: bool = Field(
         False, description="Whether this snapshot should be published publicly."
     )
+    include_first_five = Field(
+        False,
+        description="For public snapshots, whether this snapshot should include your selected First Five cards.",
+    )
     preconstructed_release: str = Field(
         None,
         description="The stub for the release for which this snapshot is the preconstructed deck. Can only be set by site admins.",

--- a/api/views/decks.py
+++ b/api/views/decks.py
@@ -523,7 +523,7 @@ def create_snapshot(
                     count=deck_die.count,
                 )
             )
-    if deck.selected_cards:
+    if deck.selected_cards and (data.include_first_five or not data.is_public):
         for deck_selected_card in deck.selected_cards:
             session.add(
                 DeckSelectedCard(


### PR DESCRIPTION
Snapshots now must be valid decks to be published, added check to ensure that admins cannot mark a private snapshot as a preconstructed release snapshot, and first five selections are now opt-in for published decks.