### PR TITLE
Bugfix: dice filters

### DIFF
--- a/api/tests/cards/test_cards.py
+++ b/api/tests/cards/test_cards.py
@@ -78,8 +78,9 @@ def test_card_filters_basic_cost(client: TestClient, session: db.Session):
     # Show only cards with basic costs
     response = client.get("/v2/cards", params={"dice": "basic"})
     assert response.status_code == status.HTTP_200_OK, response.json()
-    # There are five cards that require basic or no costs: ready spell, alteration, and all conjurations
-    assert len(response.json()["results"]) == 5, names_from_results(response)
+    # There are two cards that require basic or no costs: the ready spell and alteration
+    #  (conjurations are intentionally excluded)
+    assert len(response.json()["results"]) == 2, names_from_results(response)
 
 
 def test_card_filters_dice_costs(client: TestClient, session: db.Session):

--- a/api/views/cards.py
+++ b/api/views/cards.py
@@ -136,7 +136,13 @@ def list_cards(
         if dice_logic is CardsFilterDiceLogic.any_:
             if "basic" in dice_set:
                 dice_filters.append(
-                    db.and_(Card.dice_flags == 0, Card.alt_dice_flags == 0)
+                    db.and_(
+                        Card.dice_flags == 0,
+                        Card.alt_dice_flags == 0,
+                        Card.card_type.notin_(
+                            ["Conjuration", "Conjured Alteration Spell"]
+                        ),
+                    )
                 )
                 dice_set.remove("basic")
             # Only add additional filters if we requested more than basic cards
@@ -187,7 +193,9 @@ def list_cards(
                 dice_filters.append(
                     db.and_(
                         Card.dice_flags == sum(subset),
-                        Card.alt_dice_flags.op("&")(missing_values) == missing_values,
+                        Card.alt_dice_flags.op("&")(missing_values) == missing_values
+                        if missing_values
+                        else Card.alt_dice_flags == missing_values,
                     )
                 )
         query = query.filter(db.or_(*dice_filters))


### PR DESCRIPTION
This fixes the remaining problems I know of with dice filters (e.g. a single ALL filter for ceremonial was showing Living Doll, despite it requiring other dice types; similarly, a ceremonial and natural ANY filter was showing Living Doll even though it required dice types that weren't ceremonial or natural).