### PR TITLE
Added direct share UUID output for owned snapshots and public snapshots

### DIFF
--- a/api/schemas/decks.py
+++ b/api/schemas/decks.py
@@ -103,6 +103,10 @@ class DeckOut(BaseModel):
     id: int
     entity_id: int
     source_id: int = None
+    direct_share_uuid: UUID4 = Field(
+        None,
+        description="Only included for public snapshots, or decks/snapshots owned by the requesting user. This UUID is used to directly access deck details without requiring authentication (e.g. for private sharing).",
+    )
     title: str = None
     created: datetime
     modified: datetime
@@ -142,10 +146,6 @@ class DeckSaveOut(DeckOut):
 class DeckFullOut(DeckSaveOut):
     """Full deck information."""
 
-    direct_share_uuid: UUID4 = Field(
-        None,
-        description="Only included for public snapshots, or decks/snapshots owned by the requesting user. This UUID is used to directly access deck details without requiring authentication (e.g. for private sharing).",
-    )
     # These are generated properties; not innate parts of the Deck model
     is_saved: bool = Field(
         None,

--- a/api/services/deck.py
+++ b/api/services/deck.py
@@ -382,6 +382,7 @@ def generate_deck_dict(
     card_id_to_conjurations: Dict[int, List[Card]],
     deck_cards: List[DeckCard] = None,
     deck_dice: List[DeckDie] = None,
+    include_share_uuid: bool = False,
 ) -> dict:
     """Formats a deck into the standard deck output dict after looking up card data beforehand.
 
@@ -459,6 +460,8 @@ def generate_deck_dict(
         "is_public": deck.is_public,
         "is_snapshot": deck.is_snapshot,
     }
+    if include_share_uuid:
+        deck_dict["direct_share_uuid"] = deck.direct_share_uuid
     # Legacy-only data
     if deck.is_legacy:
         deck_dict["is_legacy"] = True
@@ -468,7 +471,7 @@ def generate_deck_dict(
 
 
 def paginate_deck_listing(
-    query: db.Query, session: db.Session, request: Request, paging: PaginationOptions
+    query: db.Query, session: db.Session, request: Request, paging: PaginationOptions, include_share_uuids: bool = False
 ) -> dict:
     """Generates a paginated deck listing using as few queries as possible."""
     # Gather our paginated results
@@ -509,6 +512,7 @@ def paginate_deck_listing(
                 card_id_to_conjurations=card_id_to_conjurations,
                 deck_cards=deck_id_to_deck_cards[deck.id],
                 deck_dice=deck_id_to_dice.get(deck.id),
+                include_share_uuid=include_share_uuids,
             )
         )
     output["results"] = deck_output
@@ -516,7 +520,7 @@ def paginate_deck_listing(
 
 
 def deck_to_dict(
-    session: db.Session, deck: Deck, include_comment_entity_id=False
+    session: db.Session, deck: Deck, include_comment_entity_id=False, include_share_uuid=False
 ) -> dict:
     """Converts a Deck object into an output dict using as few queries as possible."""
     needed_cards = set()
@@ -538,6 +542,7 @@ def deck_to_dict(
         card_id_to_conjurations=card_id_to_conjurations,
         deck_cards=deck_cards,
         deck_dice=deck_dice,
+        include_share_uuid=include_share_uuid,
     )
     deck_dict["description"] = deck.description
     deck_dict["is_public"] = deck.is_public

--- a/api/views/decks.py
+++ b/api/views/decks.py
@@ -157,7 +157,7 @@ def get_private_deck(
         raise NotFoundException(
             detail="No such deck; it might have been deleted, or your share ID might be wrong."
         )
-    deck_dict = deck_to_dict(session, deck=deck)
+    deck_dict = deck_to_dict(session, deck=deck, include_share_uuid=True)
     return deck_dict
 
 
@@ -239,7 +239,7 @@ def get_deck(
         if not deck:
             raise NotFoundException(detail="Deck not found.")
 
-    deck_dict = deck_to_dict(session, deck=deck, include_comment_entity_id=True)
+    deck_dict = deck_to_dict(session, deck=deck, include_comment_entity_id=True, include_share_uuid=own_deck or deck.is_public)
 
     # Add our `is_saved` flag, if we're viewing a saved deck
     if not source_deck.is_snapshot and show_saved:
@@ -549,7 +549,7 @@ def list_snapshots(
     query = query.options(db.joinedload(Deck.user)).order_by(
         getattr(Deck.created, order)()
     )
-    return paginate_deck_listing(query, session, request, paging)
+    return paginate_deck_listing(query, session, request, paging, include_share_uuids=not current_user.is_anonymous() and current_user.id == source_deck.user_id)
 
 
 @router.delete(


### PR DESCRIPTION
This is needed by the front-end to provide the share link in history listings.