### PR TITLE
Fix example_data.sh so that it points to the correct location of docker-entrypoint.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ testing data in your database (note: this may fail if you have never run `make r
 **Please note:** if you do *not* use the example data, you will need to install the extension
 `pgcrypto` before running any migrations (via the SQL `create extension pgcrypto;`).
 
-At this point, you can execute `make run` to start a local development server, and view your
+At this point, you can execute `make up` to start a local development server, and view your
 site's API documentation at <http:localhost:8000>.
 
 From within the API docs, you can query the API directly and inspect its output. If you need

--- a/docker/scripts/example_data.sh
+++ b/docker/scripts/example_data.sh
@@ -3,7 +3,7 @@
 echo 'Populating example data...'
 
 # Source the functions we need to get the database up and running
-source /docker-entrypoint.sh
+source ./usr/local/bin/docker-entrypoint.sh
 
 # Launch the temporary server using the same logic as the entrypoint
 export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"


### PR DESCRIPTION
When installing the project so I could hack on it, I ran into the issue described here:  https://github.com/onecrayon/api.ashes.live/issues/84.  I think this commit should fix and close that issue.

I noticed while doing a find for `docker-entrypoint.sh` that the location of this file inside of the container running the postgres process was tucked in `/usr/local/bin`.  Changing the example_data.sh script to point to this location seems to correct this issue.  After this change, I was able to seed the example data and run everything locally with no issues.

I also made a very minor change to the README to make running the server a tad more clear (there is no `make run`, I believe it should be `make up` 😄 )