### PR TITLE
Force pagination to max out at the maximum limit

### DIFF
--- a/api/schemas/pagination.py
+++ b/api/schemas/pagination.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Any, Annotated
+from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, BeforeValidator
+from pydantic import BaseModel, BeforeValidator, Field
 
 from api.environment import settings
 

--- a/api/tests/cards/test_cards.py
+++ b/api/tests/cards/test_cards.py
@@ -6,7 +6,7 @@ from api import db
 from api.models.release import Release, UserRelease
 from api.services.card import create_card
 
-from ..utils import create_user_token
+from ..utils import create_user_token, monkeypatch_settings
 
 
 def names_from_results(response):
@@ -207,6 +207,17 @@ def test_pagination_paging(client: TestClient, session: db.Session):
     assert data["count"] == 10
     assert len(data["results"]) == 3
     assert data["previous"] is not None
+    assert data["next"] is not None
+
+
+def test_pagination_exceed_limit(client: TestClient, session: db.Session, monkeypatch):
+    """Exceeding the max pagination limit results in getting the max limit back"""
+    monkeypatch_settings(monkeypatch, {"pagination_max_limit": 4, "pagination_default_limit": 2})
+    response = client.get("/v2/cards", params={"limit": 5})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 10
+    assert len(data["results"]) == 4
     assert data["next"] is not None
 
 

--- a/api/tests/cards/test_cards.py
+++ b/api/tests/cards/test_cards.py
@@ -212,7 +212,9 @@ def test_pagination_paging(client: TestClient, session: db.Session):
 
 def test_pagination_exceed_limit(client: TestClient, session: db.Session, monkeypatch):
     """Exceeding the max pagination limit results in getting the max limit back"""
-    monkeypatch_settings(monkeypatch, {"pagination_max_limit": 4, "pagination_default_limit": 2})
+    monkeypatch_settings(
+        monkeypatch, {"pagination_max_limit": 4, "pagination_default_limit": 2}
+    )
     response = client.get("/v2/cards", params={"limit": 5})
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
If the user passes in a number in excess of the max limit, we just use the max. This ensures that the endpoint returns without a validation error getting generated by the internal Pydantic logic.

Closes #88.